### PR TITLE
feat: add async_perpetual_request to client_session

### DIFF
--- a/include/foxy/client_session.hpp
+++ b/include/foxy/client_session.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot com)
+// Copyright (c) 2023 Catamorphic Co. d/b/a LaunchDarkly
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -77,6 +78,12 @@ public:
     typename boost::asio::async_result<std::decay_t<RequestHandler>,
                                        void(boost::system::error_code)>::return_type;
 
+  template <class Request, class ResponseParser, class RequestHandler>
+  auto
+  async_perpetual_request(Request const& request, ResponseParser& parser, RequestHandler&& handler) & ->
+    typename boost::asio::async_result<std::decay_t<RequestHandler>,
+                                       void(boost::system::error_code)>::return_type;
+
   template <class ShutdownHandler>
   auto
   async_shutdown(ShutdownHandler&& handler) & ->
@@ -97,6 +104,7 @@ using client_session = basic_client_session<
 
 #include <foxy/impl/client_session/async_connect.impl.hpp>
 #include <foxy/impl/client_session/async_request.impl.hpp>
+#include <foxy/impl/client_session/async_perpetual_request.impl.hpp>
 #include <foxy/impl/client_session/async_shutdown.impl.hpp>
 
 #endif // FOXY_CLIENT_SESSION_HPP_

--- a/include/foxy/impl/client_session/async_perpetual_request.impl.hpp
+++ b/include/foxy/impl/client_session/async_perpetual_request.impl.hpp
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot com)
+// Copyright (c) 2023 Catamorphic Co. d/b/a LaunchDarkly
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/LeonineKing1199/foxy
+//
+
+#ifndef FOXY_IMPL_CLIENT_SESSION_ASYNC_REQUEST_IMPL_HPP_
+#define FOXY_IMPL_CLIENT_SESSION_ASYNC_REQUEST_IMPL_HPP_
+
+#include <foxy/client_session.hpp>
+
+namespace foxy
+{
+template <class DynamicBuffer>
+template <class Request, class ResponseParser, class RequestHandler>
+auto
+basic_client_session<DynamicBuffer>::async_perpetual_request(Request const&   request,
+                                                             ResponseParser&  parser,
+                                                             RequestHandler&& handler) & ->
+  typename boost::asio::async_result<std::decay_t<RequestHandler>,
+                                     void(boost::system::error_code)>::return_type
+{
+  return ::foxy::detail::async_timer<void(boost::system::error_code)>(
+    [&request, &parser, self = this, coro = boost::asio::coroutine()](
+      auto& cb, boost::system::error_code ec = {}, std::size_t bytes_transferrred = 0) mutable {
+      auto& s = *self;
+
+      BOOST_ASIO_CORO_REENTER(coro)
+      {
+        BOOST_ASIO_CORO_YIELD
+        boost::beast::http::async_write(s.stream, request, std::move(cb));
+        if (ec) { goto upcall; }
+
+        for (;;) {
+          BOOST_ASIO_CORO_YIELD
+          boost::beast::http::async_read_some(s.stream, s.buffer, parser, std::move(cb));
+          if (ec) { goto upcall; }
+        }
+
+      upcall:
+        cb.complete(ec);
+      }
+    },
+    *this, std::forward<RequestHandler>(handler));
+}
+
+} // namespace foxy
+
+#endif // FOXY_IMPL_CLIENT_SESSION_ASYNC_REQUEST_IMPL_HPP_


### PR DESCRIPTION
This represents an HTTP request that never ends (except in error conditions), suitable for the Server-Sent-Events protocol.